### PR TITLE
imdario/go-ulid removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ From ourselves and the community!
 | [Erlang](https://github.com/savonarola/ulid) | [savonarola](https://github.com/savonarola) |
 | [Elixir](https://github.com/merongivian/ulid) | [merongivian](https://github.com/merongivian) |
 | [F#](https://github.com/lucasschejtman/FSharp.Ulid) | [lucasschejtman](https://github.com/lucasschejtman) |
-| [Go](https://github.com/imdario/go-ulid) | [imdario](https://github.com/imdario/) |
 | [Go](https://github.com/oklog/ulid) | [oklog](https://github.com/oklog) | ✓ |
 | [Haskell](https://github.com/steven777400/ulid) | [steven777400](https://github.com/steven777400) | ✓ |
 | [Java](https://github.com/huxi/sulky/tree/master/sulky-ulid) | [huxi](https://github.com/huxi) | ✓ |


### PR DESCRIPTION
I archived my repository in favor of oklog's ULID.