### PR TITLE
Fixes date of timestamp overflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Below is the current specification of ULID as implemented in this repository.
 **Timestamp**
 - 48 bit integer
 - UNIX-time in milliseconds
-- Won't run out of space until `+10889-08-02T05:31:50.655Z`.
+- Won't run out of space till the year 10889 AD.
 
 **Randomness**
 - 80 bits

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Below is the current specification of ULID as implemented in this repository.
 **Timestamp**
 - 48 bit integer
 - UNIX-time in milliseconds
-- Won't run out of space till the year 10895 AD.
+- Won't run out of space until `+10889-08-02T05:31:50.655Z`.
 
 **Randomness**
 - 80 bits


### PR DESCRIPTION
The overflow year given in the spec is over five years after the actual timestamp overflow.

This java code
```java
import java.time.Instant;

public class UlidMaxTimestamp {
    public static void main(String[] args) {
        System.out.println(Instant.ofEpochMilli(0xFFFF_FFFF_FFFFL));
    }
}
```
prints `+10889-08-02T05:31:50.655Z`.

Similar [Rust code](http://play.integer32.com/?gist=015ede4f85193b25c079f53799cce518&version=stable) prints `+10889-08-02 05:31:50.655 UTC`.