### PR TITLE
till->'til for English

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Below is the current specification of ULID as implemented in this repository.
 **Timestamp**
 - 48 bit integer
 - UNIX-time in milliseconds
-- Won't run out of space till the year 10889 AD.
+- Won't run out of space 'til the year 10889 AD.
 
 **Randomness**
 - 80 bits


### PR DESCRIPTION
To till is to maintain a field; a till is a cash drawer.  Neither of these are the abbreviation of 'until'.