### PR TITLE
Add Java implementation (ulid-creator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ From ourselves and the community!
 | [Java](https://github.com/huxi/sulky/tree/master/sulky-ulid) | [huxi](https://github.com/huxi) | ✓ |
 | [Java](https://github.com/azam/ulidj) | [azam](https://github.com/azam) |
 | [Java](https://github.com/Lewiscowles1986/jULID) | [Lewiscowles1986](https://github.com/Lewiscowles1986) |
-| [Java](https://github.com/f4b6a3/ulid-creator) | [f4b6a3](https://github.com/f4b6a3) | ✓ |
+| [Java](https://github.com/f4b6a3/ulid-creator) | [fabiolimace](https://github.com/fabiolimace) | ✓ |
 | [JavaScript](https://github.com/ulid/javascript) | [ulid](https://github.com/ulid) |
 | [JavaScript](https://github.com/aarondcohen/id128) | [aarondcohen](https://github.com/aarondcohen) | ✓ |
 | [Julia](https://github.com/ararslan/ULID.jl) | [ararslan](https://github.com/ararslan) |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ From ourselves and the community!
 | [Java](https://github.com/huxi/sulky/tree/master/sulky-ulid) | [huxi](https://github.com/huxi) | ✓ |
 | [Java](https://github.com/azam/ulidj) | [azam](https://github.com/azam) |
 | [Java](https://github.com/Lewiscowles1986/jULID) | [Lewiscowles1986](https://github.com/Lewiscowles1986) |
+| [Java](https://github.com/f4b6a3/ulid-creator) | [f4b6a3](https://github.com/f4b6a3) | ✓ |
 | [JavaScript](https://github.com/ulid/javascript) | [ulid](https://github.com/ulid) |
 | [JavaScript](https://github.com/aarondcohen/id128) | [aarondcohen](https://github.com/aarondcohen) | ✓ |
 | [Julia](https://github.com/ararslan/ULID.jl) | [ararslan](https://github.com/ararslan) |


### PR DESCRIPTION
This PR adds a library that implements the ULID spec.

### ULID Creator

ULID Creator is a Java library that generates ULIDs

Project on Github: https://github.com/f4b6a3/ulid-creator

#### How to Use

Create a ULID:

```java
Ulid ulid = UlidCreator.getUlid();
```

Create a Monotonic ULID:

```java
Ulid ulid = UlidCreator.getMonotonicUlid();
```

#### Maven dependency

Add these lines to your `pom.xml`.

```xml
<!-- https://search.maven.org/artifact/com.github.f4b6a3/ulid-creator -->
<dependency>
  <groupId>com.github.f4b6a3</groupId>
  <artifactId>ulid-creator</artifactId>
  <version>4.1.2</version>
</dependency>
```
See more options in [maven.org](https://search.maven.org/artifact/com.github.f4b6a3/ulid-creator).

#### Other usage examples

Create a ULID from a canonical string (26 chars):

```java
Ulid ulid = Ulid.from("0123456789ABCDEFGHJKMNPQRS");
```

Convert a ULID into a canonical string in upper case:

```java
String string = ulid.toString(); // 0123456789ABCDEFGHJKMNPQRS
```

Convert a ULID into a canonical string in lower case:

```java
String string = ulid.toLowerCase(); // 0123456789abcdefghjkmnpqrs
```

Convert a ULID into a UUID:

```java
UUID uuid = ulid.toUuid(); // 0110c853-1d09-52d8-d73e-1194e95b5f19
```

Convert a ULID into a [RFC-4122](https://tools.ietf.org/html/rfc4122) UUID v4:

```java
UUID uuid = ulid.toRfc4122().toUuid(); // 0110c853-1d09-42d8-973e-1194e95b5f19
                                       //               ^ UUID v4
```

Convert a ULID into a byte array:

```java
byte[] bytes = ulid.toBytes(); // 16 bytes (128 bits)
```

Get the creation instant of a ULID:

```java
Instant instant = ulid.getInstant(); // 2007-02-16T02:13:14.633Z
```
