### PR TITLE
Add link to Crockford Base 32 spec online.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ulid() // 01ARZ3NDEKTSV4RRFFQ69G5FAV
 - 1.21e+24 unique ULIDs per millisecond
 - Lexicographically sortable!
 - Canonically encoded as a 26 character string, as opposed to the 36 character UUID
-- Uses Crockford's base32 for better efficiency and readability (5 bits per character)
+- Uses [Crockford's Base 32](https://www.crockford.com/base32.html) encoding scheme for better efficiency and readability (5 bits per character)
 - Case insensitive
 - No special characters (URL safe)
 - Monotonic sort order (correctly detects and handles the same millisecond)


### PR DESCRIPTION
Fix toward https://github.com/ulid/spec/issues/49