### PR TITLE
Add common lisp implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ From ourselves and the community!
 | [C++](https://github.com/suyash/ulid) | [suyash](https://github.com/suyash) | ✓ |
 | [C#](https://github.com/mcb2001/CSharp.Ulid) | [mcb2001](https://github.com/mcb2001) |
 | [Clojure](https://github.com/theikkila/clj-ulid) | [theikkila](https://github.com/theikkila) |
+| [Common Lisp](https://gitlab.com/colinstrickland/cms-ulid)|[cms](https://www.beatworm.co.uk)|✓|
 | [Objective-C](https://github.com/whitesmith/ulid) | [ricardopereira](https://github.com/ricardopereira) |
 | [Crystal](https://github.com/SuperPaintman/ulid) | [SuperPaintman](https://github.com/SuperPaintman) |
 | [Dart](https://github.com/agilord/ulid) | [isoos](https://github.com/isoos) | ✓ |


### PR DESCRIPTION
I have a common lisp implementation of the spec I made for my own use, because I couldn't find a complete enough implementation.