### PR TITLE
fix(readme): change year notation from "AD" to "CE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Below is the current specification of ULID as implemented in [ulid/javascript](h
 **Timestamp**
 - 48 bit integer
 - UNIX-time in milliseconds
-- Won't run out of space 'til the year 10889 AD.
+- Won't run out of space 'til the year 10889 CE.
 
 **Randomness**
 - 80 bits


### PR DESCRIPTION
Nothing wrong with [AD](https://en.wikipedia.org/wiki/Anno_Domini), but [CE](https://en.wikipedia.org/wiki/Common_Era) should be increasingly more recognizable, especially in the context of (computer) science.